### PR TITLE
Get MINIXCompat building on Linux

### DIFF
--- a/MINIXCompat/MINIXCompat_Emulation.c
+++ b/MINIXCompat/MINIXCompat_Emulation.c
@@ -15,6 +15,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <arpa/inet.h> /* for ntohs et al */
+
 #include "MINIXCompat_Types.h"
 #include "MINIXCompat_Executable.h"
 #include "MINIXCompat_SysCalls.h"
@@ -109,7 +111,7 @@ int MINIXCompat_CPU_Trap_Callback(int trap)
                     m68k_set_reg(M68K_REG_D0, 0xFFFFFFFF);
                     break;
             }
-            
+
             handled = true;
         } break;
 

--- a/MINIXCompat/MINIXCompat_Executable.c
+++ b/MINIXCompat/MINIXCompat_Executable.c
@@ -238,7 +238,7 @@ static int MINIXExecutableRelocate(FILE *pef, struct MINIXCompat_Executable *peh
 
                 MINIXExecutableRelocateLongAtOffset(buf, MINIXCompat_Executable_Base, relocation_offset);
             } else if ((b & 0x01) == 0x01) {
-                return -EBADEXEC;
+                return -ENOEXEC;
             }
         } while (!done);
     }

--- a/MINIXCompat/MINIXCompat_Filesystem.c
+++ b/MINIXCompat/MINIXCompat_Filesystem.c
@@ -18,11 +18,16 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <arpa/inet.h> /* for ntohs et al */
 #include <sys/stat.h>
 
 #include "MINIXCompat_Types.h"
 #include "MINIXCompat_Errors.h"
 
+#ifndef HTONS
+#define HTONS(x) ((x) = htons(x))
+#define HTONL(x) ((x) = htonl(x))
+#endif
 
 MINIXCOMPAT_SOURCE_BEGIN
 

--- a/MINIXCompat/MINIXCompat_Filesystem.c
+++ b/MINIXCompat/MINIXCompat_Filesystem.c
@@ -477,9 +477,9 @@ static void MINIXCompat_File_MINIXStatBufForHostStatBuf(minix_stat_t * _Nonnull 
     minix_stat_buf->st_gid = host_stat_buf->st_gid; //xxx translate?
     minix_stat_buf->st_rdev = host_stat_buf->st_rdev; //xxx translate?
     minix_stat_buf->st_size = MINIXCompat_File_MINIXStatSizeForHostStatSize(host_stat_buf->st_size);
-    minix_stat_buf->minix_st_atime = (minix_time_t) host_stat_buf->st_atimespec.tv_sec;
-    minix_stat_buf->minix_st_mtime = (minix_time_t) host_stat_buf->st_mtimespec.tv_sec;
-    minix_stat_buf->minix_st_ctime = (minix_time_t) host_stat_buf->st_ctimespec.tv_sec;
+    minix_stat_buf->minix_st_atime = (minix_time_t) host_stat_buf->st_atim.tv_sec;
+    minix_stat_buf->minix_st_mtime = (minix_time_t) host_stat_buf->st_mtim.tv_sec;
+    minix_stat_buf->minix_st_ctime = (minix_time_t) host_stat_buf->st_ctim.tv_sec;
 }
 
 int16_t MINIXCompat_File_Stat(const char * _Nonnull minix_path, minix_stat_t * _Nonnull minix_stat_buf)

--- a/MINIXCompat/MINIXCompat_Messages.c
+++ b/MINIXCompat/MINIXCompat_Messages.c
@@ -16,6 +16,10 @@
 
 #include "MINIXCompat_Types.h"
 
+#ifndef HTONS
+#define HTONS(x) ((x) = htons(x))
+#define HTONL(x) ((x) = htonl(x))
+#endif
 
 MINIXCOMPAT_SOURCE_BEGIN
 
@@ -25,7 +29,7 @@ MINIXCOMPAT_SOURCE_BEGIN
 static void MINIXCompat_Message_Swap_header(minix_message_t * _Nonnull msg)
 {
     assert(msg != NULL);
-    
+
     HTONS(msg->m_source);
     HTONS(msg->m_type);
 }

--- a/MINIXCompat/MINIXCompat_Processes.c
+++ b/MINIXCompat/MINIXCompat_Processes.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <arpa/inet.h> /* for ntohs et al */
 #include <sys/stat.h>
 
 #include "MINIXCompat_Types.h"

--- a/MINIXCompat/MINIXCompat_Processes.c
+++ b/MINIXCompat/MINIXCompat_Processes.c
@@ -308,7 +308,7 @@ static int MINIXCompat_Processes_HostSignalForMINIXSignal(minix_signal_t minix_s
         case minix_SIGILL: return SIGILL;
         case minix_SIGTRAP: return SIGTRAP;
         case minix_SIGABRT: return SIGABRT;
-        case minix_SIGUNUSED: return SIGEMT; // Should never be used, but available just in case.
+        case minix_SIGUNUSED: return SIGXFSZ; // Should never be used, but available just in case.
         case minix_SIGFPE: return SIGFPE;
         case minix_SIGKILL: return SIGKILL;
         case minix_SIGUSR1: return SIGUSR1;

--- a/MINIXCompat/MINIXCompat_Processes.c
+++ b/MINIXCompat/MINIXCompat_Processes.c
@@ -20,6 +20,7 @@
 
 #include <arpa/inet.h> /* for ntohs et al */
 #include <sys/stat.h>
+#include <sys/wait.h>
 
 #include "MINIXCompat_Types.h"
 #include "MINIXCompat.h"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 CC = clang
 
 CFLAGS = -O2 -Wall
-CPPFLAGS += -MMD -IMusashi
+CPPFLAGS += -MMD -IMusashi -IMINIXCompat -DMUSASHI_CNF='"MINIXCompat_Musashi.h"'
 LIBS ::= -lm
 
 CC_FOR_BUILD ?= $(CC)


### PR DESCRIPTION
I got MINIXCompat to build on Linux with these changes (though I'm not sure it works quite correctly yet – is there a simple known-good test case I could run to test it?).

I've not been able to test whether these changes regress the build on macOS. I'd not expect it to, since the changes make MINIXCompat use more standard interfaces, but you can never know.

I've sequenced this merge request after #1.