### PR TITLE
Set correct config for Musashi in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 CC = clang
 
 CFLAGS = -O2 -Wall
-CPPFLAGS += -MMD -IMusashi
+CPPFLAGS += -MMD -IMusashi -IMINIXCompat -DMUSASHI_CNF='"MINIXCompat_Musashi.h"'
 LIBS ::= -lm
 
 CC_FOR_BUILD ?= $(CC)


### PR DESCRIPTION
It was falling back to the default config, which made the trap handler not execute properly.