### PR TITLE
Implement signal handling

### DIFF
--- a/MINIXCompat/MINIXCompat.c
+++ b/MINIXCompat/MINIXCompat.c
@@ -73,6 +73,12 @@ int main(int argc, char **argv, char **envp)
                 // Run the emulated CPU for a bunch of cycles.
 
                 (void) MINIXCompat_CPU_Run(10000);
+
+                // If the execution state hasn't changed as a result of running the emulated CPU, handle any pending signals.
+
+                if (MINIXCompat_State == MINIXCompat_Execution_State_Running) {
+                    MINIXCompat_Processes_HandlePendingSignals();
+                }
             } break;
 
             case MINIXCompat_Execution_State_Finished: {

--- a/MINIXCompat/MINIXCompat_Emulation.c
+++ b/MINIXCompat/MINIXCompat_Emulation.c
@@ -35,7 +35,7 @@ MINIXCOMPAT_SOURCE_BEGIN
 static uint8_t *MINIXCompat_RAM;
 
 
-int MINIXCompat_CPU_Trap_Callback(int trap);
+static int MINIXCompat_CPU_Trap_Callback(int trap);
 
 
 int MINIXCompat_CPU_Initialize(void)
@@ -80,7 +80,41 @@ int MINIXCompat_CPU_Run(int cycles)
 }
 
 
-int MINIXCompat_CPU_Trap_Callback(int trap)
+m68k_address_t MINIXCompat_CPU_GetPC(void)
+{
+    return m68k_get_reg(NULL, M68K_REG_PC);
+}
+
+void MINIXCompat_CPU_SetPC(m68k_address_t value)
+{
+    m68k_set_reg(M68K_REG_PC, value);
+}
+
+uint16_t MINIXCompat_CPU_GetSR(void)
+{
+    return m68k_get_reg(NULL, M68K_REG_SR);
+}
+
+m68k_address_t MINIXCompat_CPU_Push_16(uint16_t value)
+{
+    m68k_address_t sp = m68k_get_reg(NULL, M68K_REG_SP);
+    sp -= 2;
+    m68k_set_reg(M68K_REG_SP, sp);
+    MINIXCompat_RAM_Write_16(sp, value);
+    return sp;
+}
+
+m68k_address_t MINIXCompat_CPU_Push_32(uint32_t value)
+{
+    m68k_address_t sp = m68k_get_reg(NULL, M68K_REG_SP);
+    sp -= 4;
+    m68k_set_reg(M68K_REG_SP, sp);
+    MINIXCompat_RAM_Write_32(sp, value);
+    return sp;
+}
+
+
+static int MINIXCompat_CPU_Trap_Callback(int trap)
 {
     assert((trap >= 0x0) && (trap <= 0xf));
     bool handled = false;

--- a/MINIXCompat/MINIXCompat_Emulation.h
+++ b/MINIXCompat/MINIXCompat_Emulation.h
@@ -24,6 +24,23 @@ MINIXCOMPAT_EXTERN void MINIXCompat_CPU_Reset(void);
 /*! Run the CPU emulation. */
 MINIXCOMPAT_EXTERN int MINIXCompat_CPU_Run(int cycles);
 
+
+/*! Get the current program counter. */
+MINIXCOMPAT_EXTERN m68k_address_t MINIXCompat_CPU_GetPC(void);
+
+/*! Set the current program counter. */
+MINIXCOMPAT_EXTERN void MINIXCompat_CPU_SetPC(m68k_address_t value);
+
+/*! Get the status register. */
+MINIXCOMPAT_EXTERN uint16_t MINIXCompat_CPU_GetSR(void);
+
+/*! Push a 16-bit word on the stack, and return the address to which it was pushed.. */
+MINIXCOMPAT_EXTERN m68k_address_t MINIXCompat_CPU_Push_16(uint16_t value);
+
+/*! Push a 32-bit word on the stack, and return the address to which it was pushed. */
+MINIXCOMPAT_EXTERN m68k_address_t MINIXCompat_CPU_Push_32(uint32_t value);
+
+
 /*! Read the 8-bit byte at \a m68k_address from RAM. */
 MINIXCOMPAT_EXTERN uint8_t MINIXCompat_RAM_Read_8(m68k_address_t m68k_address);
 

--- a/MINIXCompat/MINIXCompat_Processes.h
+++ b/MINIXCompat/MINIXCompat_Processes.h
@@ -69,13 +69,13 @@ typedef enum minix_signal: int16_t {
 /*! The type of a MINIX signal handler. (Really a 68K-side pointer to a function that takes an `int16_t`. */
 typedef m68k_address_t minix_sighandler_t;
 
-/*! The default MINIX signal handler. */
+/*! The token that indicates the default MINIX signal handler. */
 MINIXCOMPAT_EXTERN minix_sighandler_t minix_SIG_DFL;
 
-/*! The ignoring MINIX signal handler. */
+/*! The token that indicates the ignoring MINIX signal handler. */
 MINIXCOMPAT_EXTERN minix_sighandler_t minix_SIG_IGN;
 
-/*! The error MINIX signal handler. */
+/*! The token that indicates the "error" MINIX signal handler, which is really a return code. */
 MINIXCOMPAT_EXTERN minix_sighandler_t minix_SIG_ERR;
 
 
@@ -89,6 +89,12 @@ MINIXCOMPAT_EXTERN minix_sighandler_t MINIXCompat_Processes_signal(minix_signal_
  Send a signal to a process.
  */
 MINIXCOMPAT_EXTERN int16_t MINIXCompat_Processes_kill(minix_pid_t minix_pid, minix_signal_t minix_signal);
+
+
+/*!
+ Handle any pending signals.
+ */
+MINIXCOMPAT_EXTERN void MINIXCompat_Processes_HandlePendingSignals(void);
 
 
 /*!


### PR DESCRIPTION
Thanks to a suggestion by Warren Toomey (@DoctorWkt), I’ve figured out a simple implementation of signal handling: Push the SR and PC to restore onto the stack, then the signal itself, and set the PC to the handler. This works because the handler is always wrapped by `_begsig`, which adjusts the stack itself after running to remove the signal number, and restores control to the signalled process via an `RTR` which restores both the SR and PC.