### PR TITLE
MINIXCompat/MINIXCompat_Filesystem.c: Commented out the assert(fd not already open).

### DIFF
--- a/MINIXCompat/MINIXCompat_Filesystem.c
+++ b/MINIXCompat/MINIXCompat_Filesystem.c
@@ -473,7 +473,7 @@ int16_t MINIXCompat_File_Close(minix_fd_t minix_fd)
     int16_t result;
 
     assert(MINIXCompat_fd_IsInRange(minix_fd));
-    assert(MINIXCompat_fd_IsOpen(minix_fd));
+    // assert(MINIXCompat_fd_IsOpen(minix_fd));
 
     int host_fd = MINIXCompat_fd_GetHostDescriptor(minix_fd);
 

--- a/MINIXCompat/MINIXCompat_Filesystem.c
+++ b/MINIXCompat/MINIXCompat_Filesystem.c
@@ -489,6 +489,23 @@ int16_t MINIXCompat_File_Close(minix_fd_t minix_fd)
     return result;
 }
 
+int16_t MINIXCompat_File_Mkdir(const char *minix_path, minix_mode_t minix_mode)
+{
+    int16_t result;
+
+    assert(minix_path != NULL);
+    int host_mode = MINIXCompat_File_HostOpenModeForMINIXOpenMode(minix_mode);
+
+    int mkdir_result= mkdir(minix_path, host_mode);
+    if (mkdir_result == -1) {
+        result = -MINIXCompat_Errors_MINIXErrorForHostError(errno);
+    } else {
+        result = mkdir_result;
+    }
+
+    return result;
+}
+
 int16_t MINIXCompat_File_Read(minix_fd_t minix_fd, void *host_buf, int16_t host_buf_size)
 {
     int16_t result;

--- a/MINIXCompat/MINIXCompat_Filesystem.h
+++ b/MINIXCompat/MINIXCompat_Filesystem.h
@@ -131,6 +131,9 @@ MINIXCOMPAT_EXTERN minix_fd_t MINIXCompat_File_Open(const char *minix_path, int1
 /*! Close the file with the given MINIX file descriptor. */
 MINIXCOMPAT_EXTERN int16_t MINIXCompat_File_Close(minix_fd_t fd);
 
+/*! Make the directory with the given MINIX mode */
+int16_t MINIXCompat_File_Mkdir(const char *minix_path, minix_mode_t minix_mode);
+
 /*! Reads the specified amount of data from the given file descriptor into the given host-side buffer. Returns the number of bytes read or `-errno` on error. */
 MINIXCOMPAT_EXTERN int16_t MINIXCompat_File_Read(minix_fd_t fd, void * _Nonnull buf, int16_t buf_size);
 


### PR DESCRIPTION
This allows the shell to run, although it doesn't print the prompt to the terminal.

Looking at the shell's source code, I see:
```
void
closeall()
{
        register u;

        for (u=NUFILE; u<NOFILE;)
                close(u++);
}
```

so it's trying to close a bunch of fds even if they are not actually open.

I think it's safe to remove the `assert()` because this just causes EBADF to get returned as the `errno` instead.