### PR TITLE
MINIXCompat_File_Close(): Removed assert(MINIXCompat_fd_IsOpen();

### DIFF
--- a/MINIXCompat/MINIXCompat_Filesystem.c
+++ b/MINIXCompat/MINIXCompat_Filesystem.c
@@ -473,7 +473,6 @@ int16_t MINIXCompat_File_Close(minix_fd_t minix_fd)
     int16_t result;
 
     assert(MINIXCompat_fd_IsInRange(minix_fd));
-    assert(MINIXCompat_fd_IsOpen(minix_fd));
 
     int host_fd = MINIXCompat_fd_GetHostDescriptor(minix_fd);
 


### PR DESCRIPTION
This isn't needed as `close()` can return EBADF if the fd isn't already open. This change allows /bin/sh to run, although the prompt doesn't get printed out.

Sorry Chris, I'm redoing the pull request as the old one had the mkdir changed bundled in. I'll split that into a separate pull request.