### PR TITLE
Brk fix

### DIFF
--- a/MINIXCompat/MINIXCompat_Executable.c
+++ b/MINIXCompat/MINIXCompat_Executable.c
@@ -65,6 +65,12 @@ static int MINIXExecutableLoadHeader(FILE *pef, struct MINIXCompat_Executable *p
 static void MINIXExecutableRelocateLongAtOffset(uint8_t *buf, uint32_t relocation_base, uint32_t relocation_offset);
 static int MINIXExecutableRelocate(FILE *pef, struct MINIXCompat_Executable *peh, uint8_t *buf);
 
+// The process' initial break value
+static m68k_address_t minix_initial_break = 0;
+
+m68k_address_t MINIXCompat_Executable_Get_Initial_Break(void) {
+  return minix_initial_break;
+}
 
 int MINIXCompat_Executable_Load(FILE *pef, struct MINIXCompat_Executable * _Nullable * _Nonnull out_peh, uint8_t * _Nullable * _Nonnull out_buf, uint32_t *out_buf_len)
 {
@@ -121,6 +127,10 @@ int MINIXCompat_Executable_Load(FILE *pef, struct MINIXCompat_Executable * _Null
 
     int relocate_err = MINIXExecutableRelocate(pef, peh, buf);
     if (relocate_err != 0) return -relocate_err;
+
+    // Set up the process' initial break
+    minix_initial_break= exec_h->a_text + exec_h->a_data + exec_h->a_bss;
+    printf("Setting intial break to 0x%x\n", minix_initial_break);
 
     return 0;
 }

--- a/MINIXCompat/MINIXCompat_Executable.c
+++ b/MINIXCompat/MINIXCompat_Executable.c
@@ -130,7 +130,6 @@ int MINIXCompat_Executable_Load(FILE *pef, struct MINIXCompat_Executable * _Null
 
     // Set up the process' initial break
     minix_initial_break= exec_h->a_text + exec_h->a_data + exec_h->a_bss;
-    printf("Setting intial break to 0x%x\n", minix_initial_break);
 
     return 0;
 }

--- a/MINIXCompat/MINIXCompat_Executable.h
+++ b/MINIXCompat/MINIXCompat_Executable.h
@@ -34,6 +34,11 @@ MINIXCOMPAT_EXTERN const m68k_address_t MINIXCompat_Stack_Base;
 /*! Limit of the MINIX stack, *below* which it must not grow since that would collide with initialized and uniitalized data. */
 MINIXCOMPAT_EXTERN const m68k_address_t MINIXCompat_Stack_Limit;
 
+/*!
+ Get the process' initial break value
+ */
+MINIXCOMPAT_EXTERN m68k_address_t MINIXCompat_Executable_Get_Initial_Break(void);
+
 
 /*!
  Loads a MINIX executable.

--- a/MINIXCompat/MINIXCompat_SysCalls.c
+++ b/MINIXCompat/MINIXCompat_SysCalls.c
@@ -701,8 +701,10 @@ minix_syscall_result_t MINIXCompat_SysCall_brk(minix_syscall_func_t func, uint16
 
     static m68k_address_t minix_current_break = 0;
 
+    printf("BRK: requested address 0x%x, current 0x%x, initial 0x%x\n", minix_requested_addr, minix_current_break, MINIXCompat_Executable_Get_Initial_Break());
+
     if ((minix_requested_addr < MINIXCompat_Executable_Limit)
-        && (minix_requested_addr >= minix_current_break))
+        && (minix_requested_addr >= MINIXCompat_Executable_Get_Initial_Break()))
     {
         minix_resulting_addr = minix_requested_addr;
         minix_current_break = minix_resulting_addr;


### PR DESCRIPTION
MINIXCompat/MINIXCompat_Executable.c: Calculate an initial break value,
and get BRK to use this value instead of the current value.
    
I'm not sure if I should round up the text, data and bss sizes to the
nearest click boundary. At present I'm not doing this.