### PR TITLE
MINIXCompat_SysCalls.c: Added chdir(2).

### DIFF
--- a/MINIXCompat/MINIXCompat_Filesystem.c
+++ b/MINIXCompat/MINIXCompat_Filesystem.c
@@ -732,6 +732,26 @@ minix_fd_t MINIXCompat_File_Access(const char *minix_path, minix_mode_t minix_mo
     return result;
 }
 
+minix_fd_t MINIXCompat_File_Chdir(const char *minix_path)
+{
+    int16_t result;
+
+    assert(minix_path != NULL);
+
+    char *host_path = MINIXCompat_Filesystem_CopyHostPathForPath(minix_path);
+
+    int chdir_err = chdir(host_path);
+    if (chdir_err == -1) {
+        result = -MINIXCompat_Errors_MINIXErrorForHostError(errno);
+    } else {
+        result = 0;
+    }
+
+    free(host_path);
+
+    return result;
+}
+
 
 // MARK: - Directories
 

--- a/MINIXCompat/MINIXCompat_Filesystem.h
+++ b/MINIXCompat/MINIXCompat_Filesystem.h
@@ -147,6 +147,7 @@ MINIXCOMPAT_EXTERN int16_t MINIXCompat_File_StatOpen(minix_fd_t minix_fd, minix_
 MINIXCOMPAT_EXTERN int16_t MINIXCompat_File_Unlink(const char *minix_path);
 
 MINIXCOMPAT_EXTERN minix_fd_t MINIXCompat_File_Access(const char *minix_path, minix_mode_t minix_mode);
+MINIXCOMPAT_EXTERN minix_fd_t MINIXCompat_File_Chdir(const char *minix_path);
 
 
 MINIXCOMPAT_HEADER_END


### PR DESCRIPTION
A weird thing. I run the shell and I can do `cd /, cd bin, cd ..` etc. But when I do an `ls -l`, I always get a listing of /bin.