### PR TITLE
Fix bogus information in dircache

### DIFF
--- a/MINIXCompat/MINIXCompat_Filesystem.c
+++ b/MINIXCompat/MINIXCompat_Filesystem.c
@@ -183,13 +183,13 @@ char *MINIXCompat_Filesystem_CopyHostPathForPath(const char *path)
     const size_t out_path_len = base_len + 1 /* trailing slash */ + path_len;
     char *out_path = calloc(out_path_len + 1 /* trailing NUL */, sizeof(char));
 
-    strncat(out_path, base, base_len);
+    strncat(out_path, base, out_path_len);
 
     if (!path_is_absolute) {
-        strncat(out_path, "/", 1);
+        strncat(out_path, "/", out_path_len);
     }
 
-    strncat(out_path, path, path_len);
+    strncat(out_path, path, out_path_len);
 
     return out_path;
 }
@@ -831,10 +831,10 @@ static int16_t MINIXCompat_Dir_Precache(const char * _Nullable host_path, minix_
             if (entry_count >= dircache_count) {
                 // Always increase size by one block's worth so it doesn't grow too quickly.
                 size_t new_dircache_count = (dircache_count + 32);
-                dircache = realloc(dircache, new_dircache_count * sizeof(minix_dirent_t));
-
-                // Zero-fill new entries.
-                memset(&dircache[dircache_count], 0, 32);
+                minix_dirent_t *new_dircache = calloc(new_dircache_count, sizeof(minix_dirent_t));
+                memcpy(new_dircache, dircache, dircache_count * sizeof(minix_dirent_t));
+                free(dircache);
+                dircache = new_dircache;
 
                 // Update number of available entries.
                 dircache_count = new_dircache_count;

--- a/MINIXCompat/MINIXCompat_Processes.c
+++ b/MINIXCompat/MINIXCompat_Processes.c
@@ -571,7 +571,7 @@ static void MINIXCompat_Arguments_Initialize(uint32_t host_argc, char **host_arg
         for (char **iter_argv = host_argv; *iter_argv != NULL; iter_argv++) {
             char *argv_n = *iter_argv;
             size_t argv_n_len = (uint32_t)strlen(argv_n) + 1;
-            strncpy(&content[content_offset], argv_n, argv_n_len);
+            strncpy(&content[content_offset], argv_n, content_size - content_offset);
             m68k_address_t content_addr = MINIXCompat_Stack_Base + argc_ragv_envp_size + content_offset;
             argc_argv_envp[argc_argv_envp_idx++] = htonl(content_addr);
             content_offset += round_up_32(argv_n_len);
@@ -583,7 +583,7 @@ static void MINIXCompat_Arguments_Initialize(uint32_t host_argc, char **host_arg
             char *envp_n = *iter_envp;
             if (strncmp("MINIX_", envp_n, 6) == 0) {
                 size_t envp_n_len = (uint32_t)strlen(envp_n) + 1 - 6;
-                strncpy(&content[content_offset], &envp_n[6], envp_n_len);
+                strncpy(&content[content_offset], &envp_n[6], content_size - content_offset);
                 m68k_address_t content_addr = MINIXCompat_Stack_Base + argc_ragv_envp_size + content_offset;
                 argc_argv_envp[argc_argv_envp_idx++] = htonl(content_addr);
                 content_offset += round_up_32(envp_n_len);


### PR DESCRIPTION
The code was only zeroing the first 32 *bytes* of the newly-allocated space after a successful `realloc()`, rather than all 32 *entries' worth* of space. Switched to `calloc()` plus `memcpy()` to make the intent more clear and ensure zeroing of the full allocation, since zeroing allocations are effectively free on modern systems.