### PR TITLE
Add & adopt logging subsystem

### DIFF
--- a/MINIXCompat.xcodeproj/xcshareddata/xcschemes/MINIXCompat.xcscheme
+++ b/MINIXCompat.xcodeproj/xcshareddata/xcschemes/MINIXCompat.xcscheme
@@ -87,6 +87,11 @@
             value = "/usr/bin:/bin"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "MINIXCOMPAT_LOG_DIR"
+            value = "/tmp/MC"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction

--- a/MINIXCompat/MINIXCompat.c
+++ b/MINIXCompat/MINIXCompat.c
@@ -23,13 +23,13 @@
 #include "MINIXCompat_Emulation.h"
 #include "MINIXCompat_Executable.h"
 #include "MINIXCompat_Filesystem.h"
+#include "MINIXCompat_Logging.h"
 #include "MINIXCompat_Messages.h"
 #include "MINIXCompat_Processes.h"
 #include "MINIXCompat_SysCalls.h"
 
 
 static MINIXCompat_Execution_State MINIXCompat_State = MINIXCompat_Execution_State_Started;
-static int MINIXCompat_exit_status = EX_OK;
 
 
 int main(int argc, char **argv, char **envp)
@@ -43,6 +43,7 @@ int main(int argc, char **argv, char **envp)
 
     // Initialize subsystems.
 
+    MINIXCompat_Log_Initialize();
     MINIXCompat_Filesystem_Initialize();
     MINIXCompat_CPU_Initialize();
     MINIXCompat_Processes_Initialize();
@@ -89,7 +90,7 @@ int main(int argc, char **argv, char **envp)
 
     // Exit with whatever our exit code should be.
 
-	return MINIXCompat_exit_status;
+	return MINIXCompat_Processes_ExitStatus;
 }
 
 
@@ -98,7 +99,7 @@ void MINIXCompat_Execution_ChangeState(MINIXCompat_Execution_State state)
     // Ensure a valid state transition, only these are allowed:
     // - start -> ready
     // - ready -> running
-    // - running -> ready
+    // - running -> ready (for exec)
     // - running -> finished
     // - finished -> finished (since exit(2) can be called multiple times before actually exiting)
 
@@ -109,11 +110,4 @@ void MINIXCompat_Execution_ChangeState(MINIXCompat_Execution_State state)
            || ((MINIXCompat_State == MINIXCompat_Execution_State_Finished) && (state == MINIXCompat_Execution_State_Finished)));
 
     MINIXCompat_State = state;
-}
-
-
-void MINIXCompat_exit(int status)
-{
-    MINIXCompat_exit_status = status;
-    MINIXCompat_Execution_ChangeState(MINIXCompat_Execution_State_Finished);
 }

--- a/MINIXCompat/MINIXCompat_Executable.c
+++ b/MINIXCompat/MINIXCompat_Executable.c
@@ -130,7 +130,7 @@ int MINIXCompat_Executable_Load(FILE *pef, struct MINIXCompat_Executable * _Null
     if (relocate_err != 0) return -relocate_err;
 
     // Set up the process' initial break
-    minix_initial_break= exec_h->a_text + exec_h->a_data + exec_h->a_bss;
+    minix_initial_break = exec_h->a_text + exec_h->a_data + exec_h->a_bss;
 
     return 0;
 }

--- a/MINIXCompat/MINIXCompat_Filesystem.h
+++ b/MINIXCompat/MINIXCompat_Filesystem.h
@@ -132,7 +132,7 @@ MINIXCOMPAT_EXTERN minix_fd_t MINIXCompat_File_Open(const char *minix_path, int1
 MINIXCOMPAT_EXTERN int16_t MINIXCompat_File_Close(minix_fd_t fd);
 
 /*! Make the directory with the given MINIX mode */
-int16_t MINIXCompat_File_Mkdir(const char *minix_path, minix_mode_t minix_mode);
+MINIXCOMPAT_EXTERN int16_t MINIXCompat_File_Mkdir(const char *minix_path, minix_mode_t minix_mode);
 
 /*! Reads the specified amount of data from the given file descriptor into the given host-side buffer. Returns the number of bytes read or `-errno` on error. */
 MINIXCOMPAT_EXTERN int16_t MINIXCompat_File_Read(minix_fd_t fd, void * _Nonnull buf, int16_t buf_size);

--- a/MINIXCompat/MINIXCompat_Logging.c
+++ b/MINIXCompat/MINIXCompat_Logging.c
@@ -1,0 +1,121 @@
+//
+//  MINIXCompat_Logging.c
+//  MINIXCompat
+//
+//  Created by Chris Hanson on 12/19/24.
+//  Copyright © 2024 Christopher M. Hanson. All rights reserved.
+//
+
+#include "MINIXCompat_Logging.h"
+
+#include <assert.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+
+MINIXCOMPAT_SOURCE_BEGIN
+
+
+#if DEBUG
+
+
+/*! The directory in which MINIXCompat logs are written. */
+static char *MINIXCOMPAT_LOG_DIR = NULL;
+
+/*! Cached length of `MINIXCOMPAT_LOG_DIR`. */
+static size_t MINIXCOMPAT_LOG_DIR_len = 0;
+
+/*! The ID of the process that's logging. This is used to open a new log across a `fork(2)`. */
+static pid_t MINIXCompat_Log_pid = 0;
+
+
+/*! The path to the log. */
+static char MINIXCompat_Log_Path[1024] = {0};
+
+
+/*! The file being logged to. */
+static FILE *MINIXCompat_Log_File = NULL;
+
+
+/*! Create a new log file when needed. */
+static void MINIXCompat_Log_New(void);
+
+
+void MINIXCompat_Log_Initialize(void)
+{
+    MINIXCompat_Log_pid = getpid();
+    MINIXCompat_Log_New();
+}
+
+
+void MINIXCompat_Log_New(void)
+{
+    // If there's already a log (say one that's been inherited across a fork(2), close it.
+
+    if (MINIXCompat_Log_File != NULL) {
+        fclose(MINIXCompat_Log_File);
+    }
+
+    // Get the directory to log into, using /tmp if none is specified.
+
+    if (MINIXCOMPAT_LOG_DIR == NULL) {
+        MINIXCOMPAT_LOG_DIR = getenv("MINIXCOMPAT_LOG_DIR");
+        if (MINIXCOMPAT_LOG_DIR == NULL) {
+            MINIXCOMPAT_LOG_DIR = "/tmp";
+        }
+        MINIXCOMPAT_LOG_DIR_len = strlen(MINIXCOMPAT_LOG_DIR);
+    }
+
+    // Construct a path to the log.
+
+    char name[64] = {0};
+    snprintf(name, 64, "MINIXCompat.%d", MINIXCompat_Log_pid);
+
+    MINIXCompat_Log_Path[0] = '\0';
+    strncat(MINIXCompat_Log_Path, MINIXCOMPAT_LOG_DIR, 1024);
+    if (MINIXCOMPAT_LOG_DIR[MINIXCOMPAT_LOG_DIR_len - 1] != '/') {
+        strncat(MINIXCompat_Log_Path, "/", 1024);
+    }
+    strncat(MINIXCompat_Log_Path, name, 1024);
+
+    // Open the log and crash if we can't.
+
+    MINIXCompat_Log_File = fopen(MINIXCompat_Log_Path, "w");
+    assert(MINIXCompat_Log_File != NULL);
+}
+
+
+void MINIXCompat_Log(const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    MINIXCompat_Logv(fmt, ap);
+    va_end(ap);
+}
+
+
+void MINIXCompat_Logv(const char *fmt, va_list args)
+{
+    pid_t curpid = getpid();
+    if (MINIXCompat_Log_pid != curpid) {
+        MINIXCompat_Log_pid = curpid;
+        MINIXCompat_Log_New();
+    }
+
+    fprintf(MINIXCompat_Log_File, "%d: ", curpid);
+    vfprintf(MINIXCompat_Log_File, fmt, args);
+    size_t fmt_len = strlen(fmt);
+    if (fmt[fmt_len - 1] != '\n') {
+        fprintf(MINIXCompat_Log_File, "\n");
+    }
+}
+
+
+#endif /* DEBUG */
+
+
+MINIXCOMPAT_SOURCE_END

--- a/MINIXCompat/MINIXCompat_Logging.h
+++ b/MINIXCompat/MINIXCompat_Logging.h
@@ -1,0 +1,46 @@
+//
+//  MINIXCompat_Logging.h
+//  MINIXCompat
+//
+//  Created by Chris Hanson on 12/19/24.
+//  Copyright © 2024 Christopher M. Hanson. All rights reserved.
+//
+
+#ifndef MINIXCompat_Logging_h
+#define MINIXCompat_Logging_h
+
+#include "MINIXCompat_Types.h"
+
+
+MINIXCOMPAT_HEADER_BEGIN
+
+
+#if DEBUG
+
+
+/*! Initialize the logging subsystem. */
+MINIXCOMPAT_EXTERN void MINIXCompat_Log_Initialize(void);
+
+
+/*! Log some information to the per-process log file. */
+MINIXCOMPAT_EXTERN void MINIXCompat_Log(const char *fmt, ...) __printflike(1, 2);;
+
+/*! Log some information to the per-process log file (callable). */
+MINIXCOMPAT_EXTERN void MINIXCompat_Logv(const char *fmt, va_list args);
+
+
+#else
+
+
+#define MINIXCompat_Log_Initialize()
+#define MINIXCompat_Log(fmt, ...)
+#define MINIXCompat_Logv(fmt, args)
+
+
+#endif
+
+
+MINIXCOMPAT_HEADER_END
+
+
+#endif /* MINIXCompat_Logging_h */

--- a/MINIXCompat/MINIXCompat_Processes.h
+++ b/MINIXCompat/MINIXCompat_Processes.h
@@ -43,6 +43,16 @@ MINIXCOMPAT_EXTERN minix_pid_t MINIXCompat_Processes_fork(void);
  */
 MINIXCOMPAT_EXTERN minix_pid_t MINIXCompat_Processes_wait(int16_t * _Nonnull minix_stat_loc);
 
+/*!
+ Exit with a given status.
+ */
+MINIXCOMPAT_EXTERN void MINIXCompat_Processes_exit(int16_t minix_status);
+
+/*!
+ The exit status to use.
+ */
+MINIXCOMPAT_EXTERN int MINIXCompat_Processes_ExitStatus;
+
 
 /*! The type of a MINIX signal. */
 typedef enum minix_signal: int16_t {
@@ -124,6 +134,14 @@ MINIXCOMPAT_EXTERN int16_t MINIXCompat_Processes_ExecuteWithStackBlock(const cha
  - Warning: This resets the emulation environment and should only be invoked after startup or a `fork(2)` call.
  */
 MINIXCOMPAT_EXTERN int16_t MINIXCompat_Processes_ExecuteWithHostParams(const char *executable_path, int16_t argc, char * _Nullable * _Nonnull argv, char * _Nullable * _Nonnull envp);
+
+
+/*!
+ Adjust the "break," which is the size of uninitialized data for the process.
+
+ - Note: The break can never be lower than the BSS but can extend to the top of the area reserved for the stack.
+ */
+MINIXCOMPAT_EXTERN int16_t MINIXCompat_Processes_brk(m68k_address_t minix_requested_addr, m68k_address_t * _Nonnull minix_resulting_addr);
 
 
 MINIXCOMPAT_HEADER_END

--- a/MINIXCompat/MINIXCompat_SysCalls.h
+++ b/MINIXCompat/MINIXCompat_SysCalls.h
@@ -145,12 +145,6 @@ typedef enum minix_syscall_result: int16_t {
 MINIXCOMPAT_EXTERN minix_syscall_result_t MINIXCompat_System_Call(minix_syscall_func_t func, uint16_t src_dest, m68k_address_t msg, uint32_t * _Nonnull out_result);
 
 
-/*!
- Causes MINIXCompat to `exit(2)` with the given \a status value, at an appropriate point.
- */
-MINIXCOMPAT_EXTERN void MINIXCompat_exit(int status);
-
-
 MINIXCOMPAT_HEADER_END
 
 


### PR DESCRIPTION
We need better logging than directly calling `fprintf` for handling multiple processes, so add a mechanism to enable that.